### PR TITLE
Connectors ETL

### DIFF
--- a/scripts/etl.py
+++ b/scripts/etl.py
@@ -26,7 +26,7 @@ INTERNAL_TOOLS_COLLECTION = "stats_internal_daily"
 EXTERNAL_APPS_COLLECTION = 'stats_external_daily'
 
 def internal_apps_regex():
-    regex = re.compile(r"(stitch\||mongosqld|MongoDB Automation Agent|MongoDB Atlas|MongoDB Compass|mongoimport|mongoexport|mongodump|mongorestore|mongomirror)")
+    regex = re.compile(r"(stitch\||mongosqld|mongodrdl|MongoDB Automation Agent|MongoDB Atlas|MongoDB Compass|mongoimport|mongoexport|mongodump|mongorestore|mongomirror|MongoDB PIT|MongoDB CPS|MongoDB Backup|MongoDB Monitoring)")
     return regex
 
 
@@ -45,7 +45,6 @@ def end_date(days=0):
 
 def start_and_end_date(end_date_string=None,start_date_string=None):
     end_date = get_date(end_date_string)
-    #start_date = end_date -timedelta(delta)
     start_date = get_date(start_date_string)
     return (start_date,end_date)
 
@@ -92,6 +91,7 @@ def other_drivers_names():
                 'mongo-go-driver',
                 'mongo-ruby-driver',
                 'mongo-rust-driver-prototype',
+                'mongo-rust-driver',
                 'mongoc',
                 'mongoc / ext-mongodb:HHVM',
                 'mongoc / ext-mongodb:PHP',
@@ -103,6 +103,10 @@ def other_drivers_names():
                 'nodejs-core',
                 'PyMongo',
                 'PyMongo|Motor',
+                'PyMongo|PyMODM',
+                'nodejs|Mongoose',
+                'mongo-java-driver|mongo-spark',
+                'mongo-java-driver|legacy|mongo-spark',
                 'mongo-java-driver|sync|mongo-kafka'
             ]
 
@@ -291,7 +295,6 @@ def language_version_and_framework(doc):
                 }
             else:
                 pass
-
             if language_version is not None:
                 doc['lver'] = language_version
             if framework is not None:
@@ -334,7 +337,8 @@ def function_with_time_elapsed(message):
 
 def group_external_apps(list):
     df = pd.DataFrame(list)
-    df = df.drop(columns=['a'])
+    if 'a' in df.columns:
+        df = df.drop(columns=['a'])
     df = df.replace('', ' ', regex = True)
     df = df.replace(np.nan, '', regex = True)
     df = df.groupby(['d','p','month','day','year','sv','dv','os','osa','osv','gid'],as_index=False).max().drop_duplicates()

--- a/scripts/etl_connectors.py
+++ b/scripts/etl_connectors.py
@@ -1,0 +1,61 @@
+import argparse
+import os
+import pandas as pd
+import numpy as np
+import pymongo
+import dns
+from bson.objectid import ObjectId
+import datetime
+import pprint
+from datetime import timezone, datetime, tzinfo, date,time, timedelta
+import pdb
+#import logging
+import time
+from pyathenajdbc import connect
+from queries_connectors import *
+from connections import athena_connection, postprocessing_connection
+
+def load(collection,docs):
+    conn = postprocessing_connection()
+    db = conn.connectors
+    output_collection_new = db['%s_new' % collection]
+    output_collection = db[collection]
+    try:
+        print("Filling up table {}".format(collection))
+        #pdb.set_trace()
+        output_collection_new.insert_many(docs)
+        print('inserted docs')
+    except Exception as e:
+        print(e)
+        raise
+    try:
+        print('dropping old collection')
+        output_collection.drop()
+        print('renaming new collection')
+        output_collection_new.rename(collection)
+    except Exception as e:
+        print(e)
+    finally:
+        conn.close()
+
+"""
+ETL for one collection
+"""
+def etl_for_one_collection(collection,query):
+    #extract
+    docs = run_query(query)
+    if len(docs) > 0:
+        #load
+        load(collection,docs)
+    else:
+        print('no results from the query')
+
+def etl_for_list_of_queries():
+    print("starting Athena ETLs")
+    for doc in collections_queries:
+        query = list(doc.values())[0]
+        collection_name = list(doc.keys())[0] # creating new collection to be later removed and replaced.
+        etl_for_one_collection(collection_name,query)
+
+if __name__ == "__main__":
+    etl_for_list_of_queries()

--- a/scripts/etl_connectors.py
+++ b/scripts/etl_connectors.py
@@ -12,8 +12,25 @@ import pdb
 #import logging
 import time
 from pyathenajdbc import connect
-from queries_connectors import *
+from queries_connectors import collections_queries
 from connections import athena_connection, postprocessing_connection
+
+"""
+Method for running an Athena query and returning result as list of dicts.
+"""
+def run_query(query):
+    conn = athena_connection()
+    try:
+        result = pd.read_sql(query,conn)
+        result = result.to_dict('records')
+        return result
+    except Exception as x:
+        print(x)
+        logging.error(x)
+        raise
+    finally:
+        print("closing connection")
+        conn.close()
 
 """
 Load step of the ETL for one collection and one list of docs. Creates a new
@@ -55,9 +72,12 @@ def etl_for_one_collection(collection,query):
     else:
         print('no results from the query')
 
+"""
+Running ETL for list or queries/collections
+"""
 def etl_for_list_of_queries():
     print("starting Athena ETLs")
-    for doc in collections_queries:
+    for doc in collections_queries():
         query = list(doc.values())[0]
         collection_name = list(doc.keys())[0] # creating new collection to be later removed and replaced.
         etl_for_one_collection(collection_name,query)

--- a/scripts/etl_connectors.py
+++ b/scripts/etl_connectors.py
@@ -15,6 +15,11 @@ from pyathenajdbc import connect
 from queries_connectors import *
 from connections import athena_connection, postprocessing_connection
 
+"""
+Load step of the ETL for one collection and one list of docs. Creates a new
+collection, loads data, then in case of success deletes the old one and
+renames the new one (i.e. removes the suffix "_new")
+"""
 def load(collection,docs):
     conn = postprocessing_connection()
     db = conn.connectors

--- a/scripts/queries_connectors.py
+++ b/scripts/queries_connectors.py
@@ -1,0 +1,170 @@
+from connections import athena_connection,postprocessing_connection
+import pandas as pd
+import logging
+from datetime import datetime, timezone
+from dateutil.relativedelta import *
+
+
+SPARK_NAMES = [
+    'mongo-java-driver|mongo-spark',
+    'mongo-java-driver|legacy|mongo-spark'
+]
+
+KAFKA_NAMES = [
+    'mongo-java-driver|sync|mongo-kafka|sink',
+    'mongo-java-driver|sync|mongo-kafka|source',
+    'mongo-java-driver|sync|mongo-kafka'
+]
+
+BIC_NAMES = [
+    'mongosqld',
+    'mongodrdl'
+]
+
+SOURCE_TABLE='cloud_backend_raw_stage.dw__cloud_backend__rawclientmetadata'
+
+def driver_names_joined(names_list):
+    return "'" + "','".join(names_list)+"'"
+
+def last_six_months_start_and_end_date():
+    today = datetime.today()
+    first_day_of_this_month = \
+    datetime(today.year, today.month, 1,tzinfo=timezone.utc)
+    six_months_ago = first_day_of_this_month + relativedelta(months=-6)
+    six_months_ago = six_months_ago.strftime('%Y-%m-%d')
+    first_day_of_this_month = first_day_of_this_month.strftime('%Y-%m-%d')
+    return  (six_months_ago,first_day_of_this_month)
+
+def query_new_vs_existing_6_months(names_list):
+    start_date,end_date = last_six_months_start_and_end_date()
+    query = """
+    WITH min_dates_by_month as (\
+    select gid__oid,\
+   month(rt) as month,\
+   year(rt) as year,\
+   min(rt) as min_rt_month\
+   from {0} where \
+   entries__raw__driver__name in ({1})\
+               and date(rt) >= date '{2}' and processed_date >= '{3}'\
+               and date(rt) < date '{2}' and processed_date <= '{3}'\
+               group by month(rt), year(rt), gid__oid\
+ ),\
+  min_dates_overall as (\
+    select gid__oid,\
+    min(rt) as min_rt from {0} where entries__raw__driver__name in ({1})\
+    group by gid__oid\
+    )\
+   select\
+   count_if(status = 'new') as new_projects,\
+   count_if(status = 'existing') as existing_projects,\
+   count(distinct group_id) as count_projects,\
+   min(min_rt_month) as ts,\
+   month,\
+   year\
+   from (\
+   select min_dates_by_month.gid__oid as group_id,\
+   min_rt_month, month, year, min_rt,\
+   CASE WHEN min_rt_month > min_rt THEN 'existing' ELSE 'new' END as status\
+   from\
+   min_dates_by_month join min_dates_overall on min_dates_by_month.gid__oid = min_dates_overall.gid__oid)\
+   group by month, year\
+    """.format(SOURCE_TABLE,names_list,start_date, end_date)
+    print(query)
+    return query
+
+def query_spark_new_vs_existing_6_months():
+    query = query_new_vs_existing_6_months(driver_names_joined(SPARK_NAMES))
+    return query
+
+def query_kafka_new_vs_existing_6_months():
+    query = query_new_vs_existing_6_months(driver_names_joined(KAFKA_NAMES))
+    return query
+
+def query_bic_clusters():
+    query = """
+        WITH start_of_time as \
+        (select date_add('day',-(day_of_week(current_date)-1)-56,current_date) as day)\
+
+         SELECT week, \
+           COUNT(DISTINCT CASE \
+                  WHEN bi_connector=true\
+                 THEN cluster_id ELSE NULL END)as clusters_with_bi_connector,\
+           cast(date_trunc('week',date) as timestamp) as date,\
+           ca_instance_size as instance_size\
+            from ns__data_analyst_internal.natalya_atlas_clusters_hist\
+             where date >= (select day from start_of_time limit 1)\
+            group by week, date_trunc('week',date), ca_instance_size\
+            order by week, date_trunc('week',date), ca_instance_size
+    """
+    print(query)
+    return query
+
+def query_connectors_weekly(names_list):
+    query ="""
+        WITH start_of_time as (select date_add('day',-(day_of_week(current_date)-1)-56,current_date) as day)\
+        select count(distinct group_id) as groups_count, max(ts) as max_ts,min(ts) as min_ts, week\
+        FROM \
+     (SELECT \
+     date_trunc('week',rt) as week,\
+     rt as ts,\
+     gid__oid as group_id\
+     from \
+     {0} where entries__raw__driver__name in \
+     ({1})\
+      and date(rt) >= (select day from start_of_time limit 1)\
+     )\
+     group by week\
+     order by week
+    """.format(SOURCE_TABLE,names_list)
+    print(query)
+    return query
+
+def query_bic_weekly():
+    query = query_connectors_weekly(driver_names_joined(BIC_NAMES))
+    return query
+
+def query_spark_weekly():
+    query = query_connectors_weekly(driver_names_joined(SPARK_NAMES))
+    return query
+
+def query_kafka_weekly():
+    query = query_connectors_weekly(driver_names_joined(KAFKA_NAMES))
+    return query
+
+def query_kafka_source_vs_sink_monthly():
+    query = """
+        SELECT count(distinct gid__oid) as count_groups,\
+        month(rt) as month, year(rt) as year, min(rt) as min_ts,\
+        max(rt) as max_ts,\
+        entries__raw__driver__name as driver_name\
+        from {0} \
+        where entries__raw__driver__name in ({1})\
+        and processed_date >= '2020-06-01' and rt >= date '2020-06-01'\
+        group by entries__raw__driver__name, year(rt), month(rt)\
+        order by year, month\
+    """.format(SOURCE_TABLE,driver_names_joined(KAFKA_NAMES))
+    return query
+
+collections_queries = [
+{'spark_monthly_new_vs_existing': query_spark_new_vs_existing_6_months()},
+{'kafka_monthly_new_vs_existing': query_kafka_new_vs_existing_6_months()},
+{'bic_active_clusters': query_bic_clusters()},
+{'bic_usage_weekly': query_bic_weekly()},
+{'kafka_weekly': query_kafka_weekly()},
+{'spark_weekly': query_spark_weekly()},
+{'kafka_sink_source_monthly': query_kafka_source_vs_sink_monthly()}
+]
+
+def run_query(query):
+    conn = athena_connection()
+    try:
+        result = pd.read_sql(query,conn)
+        result = result.to_dict('records')
+        return result
+    except Exception as x:
+        print(x)
+        logging.error(x)
+        raise
+    finally:
+        print("closing connection")
+        conn.close()


### PR DESCRIPTION
Implements ETL for Kafka, Spark and BI Connectors metrics (usage in Atlas). 

ETL only consists of extract and load stages (no transformation needed). 
The script can be run on any date/day of the week and will always give the following results: 
* For monthly trends, 6 months history including previous month
* For weekly trends, 8 weeks history including previous week

* Extract stage queries Athena and gets aggregated statistics
* Load stage inserts docs into Atlas cluster collections.

Resulting charts can be seen in this dashboard: 
https://charts.mongodb.com/charts-natalya-dtbfj/dashboards/2133e775-8c43-4d9d-b8b9-53a7ef9211e4

There are no options being passed to the script (yet). Can change based on Airflow implementation. 